### PR TITLE
remove self import from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-from pymlconf import __version__ as package_version
-
 # reading pymlconf version (same way sqlalchemy does)
 with open(os.path.join(os.path.dirname(__file__),'pymlconf', '__init__.py')) as v_file:
     package_version = re.compile(r".*__version__ = '(.*?)'",re.S).match(v_file.read()).group(1)


### PR DESCRIPTION
again removed line

`from pymlconf import __version__ as package_version` from setup.py

this creates cascade imports of packages that are yet to be installed, causing the fix in later lines to be non-effective
