### PR TITLE
Switch out .clear with equivalent, compatible call

### DIFF
--- a/pymlconf/config_nodes.py
+++ b/pymlconf/config_nodes.py
@@ -174,7 +174,7 @@ class ConfigList(list, Mergable):
         return data and hasattr(data, '__iter__')
 
     def _merge(self, data):
-        self.clear()
+        del self[:]
         self.extend(data)
         # for item in data:
         #     if item not in self:


### PR DESCRIPTION
list.clear is apparently not available in Python 3.2. This change removes that call in favor of clearing the list in a compatible way so that it works in older Python versions.

From the Python 3 documentation (https://docs.python.org/3/tutorial/datastructures.html#more-on-lists):

> list.clear()
> Remove all items from the list. Equivalent to del a[:].

The documentation for Python 3.2, which does not mention a .clear method: https://docs.python.org/3.2/tutorial/datastructures.html#more-on-lists

Resolves #16 